### PR TITLE
Mobile overscroll/bounce protection

### DIFF
--- a/src/parlx.js
+++ b/src/parlx.js
@@ -75,7 +75,8 @@ export default class Parlx {
   parallaxEffect() {
     this.element.style.height = this.settings.height;
 
-    const scrolled = this.element.getBoundingClientRect().top;
+    const top = this.element.getBoundingClientRect().top;
+    const scrolled = top < 0 ? top : 0;
 
     if (Math.abs(this.settings.speed) > 1) this.settings.speed = 0.3;
 


### PR DESCRIPTION
Added protection for scrolling into positive values during mobile overscroll/bounce.

On mobile devices when dragging the screen down, the parallax scrolls too far and the values for  this.element.getBoundingClientRect().top go above 0.